### PR TITLE
Add Decompile Guide to Wiki

### DIFF
--- a/docs/_general/decompile.md
+++ b/docs/_general/decompile.md
@@ -1,0 +1,22 @@
+
+# Decompile Starground Project
+Currently decompiling the game is allowed, however redistributing any of the project files is strictly forbidden. This guide will walk you thought the decompiling of the game and cover some of the basics about using it for development.
+
+  <div class="alert alert-error radius">
+<strong class="font__weight-semibold">WARNING!</strong> Keep in mind that this project, including its codebase and assets, are property of BigBoyGames, and must not be used outside of this modding scope or redistributed in any way, unless stated otherwise.
+  </div>
+
+***
+## Decompiling Requirements
+- Have the version of Starground installed via Steam.
+- You will need a custom version of Godot engine called GodotSteam found [here.]([https://github.com/GodotSteam/MultiPlayerPeer/releases/tag/v4.11-mp](https://github.com/GodotSteam/MultiPlayerPeer/releases/tag/v4.11-mp "https://github.com/GodotSteam/MultiPlayerPeer/releases/tag/v4.11-mp"))
+- You will need GDSdecomp from [here.]([https://github.com/bruvzg/gdsdecomp/releases/tag/v0.7.0-prerelease.1](https://github.com/bruvzg/gdsdecomp/releases/tag/v0.7.0-prerelease.1 "https://github.com/bruvzg/gdsdecomp/releases/tag/v0.7.0-prerelease.1"))
+- Basic understanding of Godot Engine to fix any decompile issues. (Decompile doesn't always work properly)
+
+## Setting Up Project
+This is the actual guide in order to get the source files. This may not always work if the game update changes engine version or etc.
+
+1. Open Godot RE Tools, select RE Tools from the tool bar on the top and then click the Recover project button.
+2. Navigate to your Starground installation files (On `steam: Properties > Installed Files > Browse`), select `starground.pck` and click open.
+3. Wait for it to finish loading, make sure Full Recovery is on, select your destination folder, and click extract.
+4. Open the GodotSteam Editor, and open the project generated in the last step, either by clicking Import on the Project Manager and navigating to the project folder, or by opening the `project.godot` file using GodotSteam (Regular Godot won't work).

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -8,6 +8,7 @@
 		* [Info.json Explained](_general/info-JSON.md)
 		* [What is not Possible](_general/not-possible.md)
 		* [Contributing to the Wiki](_general/wiki-contribute.md)
+		* [Decompiling Game Files](_general/decompile.md)
 * Asset Guides
     * [Art Guide](_art/Art-Guide.md)
 * Scripting Guides

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/sushantrahate/docsify-darkly-theme/css/darkly.min.css">
-  <link rel="icon" href="_media/logo_small.png" />
+  <link rel="icon" href="https://raw.githubusercontent.com/chip003/starground-modding/refs/heads/main/docs/_media/logo_small.png" />
   <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/docs/style.css
+++ b/docs/style.css
@@ -6,3 +6,23 @@
     max-width: 200px;
     max-height: 200px;
 }
+
+.alert {
+    position: relative;
+    display: block;
+    padding: 1em 1.8em;
+    font-size: 0.9em;
+    font-weight: 300;
+    line-height: 1.2;
+    text-align: left;
+    margin-top: 0.4em;
+    margin-bottom: 0.4em;
+    background: transparent;
+    color: white;
+}
+
+/* Error */ 
+.alert-error { 
+  background: #e74c3c; 
+  border: 1px solid #c0392b; 
+}


### PR DESCRIPTION
This adds how to decompile the game to the modding wiki. An alert was added to the page in order with the alert text of " Keep in mind that this project, including its codebase and assets, are property of BigBoyGames, and must not be used outside of this modding scope or redistributed in any way, unless stated otherwise. "